### PR TITLE
[codex] Use semicolon for next allowed user IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ Implemented in `bots/`.
 - `vkTeamsBot.go` provides the same for VK Teams.
 - `retry.go` contains cancellation-aware retry waiting.
 
-Incoming commands are accepted only from configured command chats. The `duty` command is restricted to `MAIN_CHAT_ID`; the `next` command is restricted to `SUPPORT_CHAT_ID` and sender user IDs listed in `NEXT_ALLOWED_USER_IDS`.
+Incoming commands are accepted only from configured command chats. The `duty` command is restricted to `MAIN_CHAT_ID`; the `next` command is restricted to `SUPPORT_CHAT_ID` and sender user IDs listed in semicolon-separated `NEXT_ALLOWED_USER_IDS`.
 
 ### Command Routing
 
@@ -94,7 +94,7 @@ Behavior of `\next`:
 
 - works only during configured working hours;
 - is accepted only from `SUPPORT_CHAT_ID`;
-- is accepted only from users listed in `NEXT_ALLOWED_USER_IDS`;
+- is accepted only from users listed in semicolon-separated `NEXT_ALLOWED_USER_IDS`;
 - returns a permission-denied response to other users;
 - requires an existing duty assignment for today;
 - selects the next person alphabetically after today's current duty person;
@@ -188,7 +188,7 @@ Important environment variables:
 - `BOT_TYPE`
 - `MAIN_CHAT_ID`
 - `SUPPORT_CHAT_ID`
-- `NEXT_ALLOWED_USER_IDS`
+- `NEXT_ALLOWED_USER_IDS` (semicolon-separated)
 - `PROBE_DELAY`
 - `DEAD_PROBE_DELAY`
 - `DEAD_PROBE_THRESHOLD`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ On shutdown it:
 - `BOT_API_URL`: Bot API URL
 - `MAIN_CHAT_ID`: Main chat ID for notifications
 - `SUPPORT_CHAT_ID`: Support chat ID for duty notifications and the `\\next` command (required for duty replacement)
-- `NEXT_ALLOWED_USER_IDS`: Comma-separated list of user IDs allowed to execute `\\next`
+- `NEXT_ALLOWED_USER_IDS`: Semicolon-separated list of user IDs allowed to execute `\\next`
 - `BOT_TYPE`: Type of bot to use (can be `telegram` or `vk`)
 - `RETRY_COUNT`: Number of attempts to send a message (default: 3)
 - `RETRY_PAUSE`: Pause between retry attempts in seconds (default: 5)
@@ -100,7 +100,7 @@ export BOT_TYPE='telegram'
 export BOT_TOKEN='your-bot-token'
 export MAIN_CHAT_ID='your-main-chat-id'
 export SUPPORT_CHAT_ID='your-support-chat-id'
-export NEXT_ALLOWED_USER_IDS='user-id-1,user-id-2'
+export NEXT_ALLOWED_USER_IDS='user-id-1;user-id-2'
 
 export PROBE_DELAY='5'
 export DEAD_PROBE_DELAY='60'

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	botApiUrl := os.Getenv("BOT_API_URL")
 	mainChatId := os.Getenv("MAIN_CHAT_ID")
 	supportChatId := os.Getenv("SUPPORT_CHAT_ID")
-	nextAllowedUserIds := parseCommaSeparatedList(os.Getenv("NEXT_ALLOWED_USER_IDS"))
+	nextAllowedUserIds := parseSemicolonSeparatedList(os.Getenv("NEXT_ALLOWED_USER_IDS"))
 	botType := os.Getenv("BOT_TYPE")
 
 	// delay between probes
@@ -215,9 +215,9 @@ func shutdownHTTPServer(httpServer *http.Server, isReady *atomic.Value) {
 	}
 }
 
-func parseCommaSeparatedList(value string) []string {
+func parseSemicolonSeparatedList(value string) []string {
 	var result []string
-	for _, item := range strings.Split(value, ",") {
+	for _, item := range strings.Split(value, ";") {
 		item = strings.TrimSpace(item)
 		if item != "" {
 			result = append(result, item)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSemicolonSeparatedList(t *testing.T) {
+	result := parseSemicolonSeparatedList(" user-1;user-2 ; ; user-3 ")
+	expected := []string{"user-1", "user-2", "user-3"}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %v, got %v", expected, result)
+	}
+}
+
+func TestParseSemicolonSeparatedListDoesNotSplitCommas(t *testing.T) {
+	result := parseSemicolonSeparatedList("user-1,user-2")
+	expected := []string{"user-1,user-2"}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %v, got %v", expected, result)
+	}
+}


### PR DESCRIPTION
## What changed

- Parse NEXT_ALLOWED_USER_IDS using semicolon instead of comma.
- Add tests for semicolon-separated values and comma preservation.
- Update README and AGENTS documentation with the new variable format.

## Why

Helm can fail when parsing environment variable values containing comma-separated lists. Switching this allow list to semicolon-separated values avoids that deployment issue.

## Validation

- make test